### PR TITLE
Fixed certificate import failure in PowerShell 7.x

### DIFF
--- a/PowerRemoteDesktop_Server/PowerRemoteDesktop_Server.psm1
+++ b/PowerRemoteDesktop_Server/PowerRemoteDesktop_Server.psm1
@@ -1900,14 +1900,13 @@ function Invoke-RemoteDesktopServer
 
         if ($CertificateFile -or $EncodedCertificate)
         {
-            $Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2
             if ($CertificateFile)
             {
-                $Certificate.Import($CertificateFile)
+                $Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 $CertificateFile
             }
             else
             {
-                $Certificate.Import([Convert]::FromBase64String($EncodedCertificate))
+                $Certificate = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 @(, [Convert]::FromBase64String($EncodedCertificate))
             }
         }
 


### PR DESCRIPTION
Because the `X509Certificate2.Import()` method is obsolete in .NET Core, the PowerRemoteDesktop_Server module cannot be executed in PowerShell 7 due to an error when importing certificates.

This PR fixes this issue so that Server works on both Windows PowerShell 5.1 and PowerShell 7.2 by changing the method to not use `X509Certificate2.Import()`.